### PR TITLE
Remove test-scope dependency on jamm-0.2.5 because it conflicts with …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,13 +226,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.github.stephenc</groupId>
-            <artifactId>jamm</artifactId>
-            <version>0.2.5</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-library</artifactId>
             <version>1.3</version>


### PR DESCRIPTION
…a later version and causes NoSuchMethodError when running unit tests in Eclipse